### PR TITLE
Fix run scripts for CPU-only usage

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,6 @@ set -e
 
 echo "Iniciando o container pytorch-tkinter-app"
 docker run \
-  --gpus all \
   --rm \
   -e DISPLAY=${DISPLAY} \
   -v /tmp/.X11-unix:/tmp/.X11-unix \

--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,8 @@ docker run \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
   -v "$(pwd)/app.py":/app/app.py:ro \
   -v "$(pwd)/dataset":/app/dataset:ro \
+  -v "$(pwd)/gui":/app/gui:ro \
+  -v "$(pwd)/utils":/app/utils:ro \
   -w /app \
   pytorch-tkinter-app
 

--- a/run_wsl.sh
+++ b/run_wsl.sh
@@ -8,7 +8,6 @@ HOST_IP=$(grep nameserver /etc/resolv.conf | awk '{print $2}')
 export DISPLAY=${HOST_IP}:0
 
 docker run \
-  --gpus all \
   --rm \
   -e DISPLAY=${DISPLAY} \
   -v /tmp/.X11-unix:/tmp/.X11-unix \


### PR DESCRIPTION
## Summary
- remove the `--gpus all` flag from `run.sh` and `run_wsl.sh` so the container can start without GPU

## Testing
- `bash build.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684cfd32a5c08331b5bfaa60b7e208b2